### PR TITLE
Consider any invalid arguments to Schedule.new a Repeatable::ParseError

### DIFF
--- a/lib/repeatable/schedule.rb
+++ b/lib/repeatable/schedule.rb
@@ -9,7 +9,7 @@ module Repeatable
       when Hash
         @expression = Parser.call(arg)
       else
-        fail(ArgumentError, "Can't build a Repeatable::Schedule from #{arg.class}")
+        fail(ParseError, "Can't build a Repeatable::Schedule from #{arg.class}")
       end
     end
 

--- a/spec/repeatable/schedule_spec.rb
+++ b/spec/repeatable/schedule_spec.rb
@@ -27,7 +27,7 @@ module Repeatable
         let(:arg) { 'a random string' }
 
         it 'raises a ArgumentError' do
-          expect { subject }.to raise_error(ArgumentError, "Can't build a Repeatable::Schedule from String")
+          expect { subject }.to raise_error(ParseError, "Can't build a Repeatable::Schedule from String")
         end
       end
     end


### PR DESCRIPTION
With this change, consumers can rescue from one specific error when trying to instantiate a Schedule.