### PR TITLE
Allow day_in_month to take :last as a parameter

### DIFF
--- a/lib/repeatable/expression/day_in_month.rb
+++ b/lib/repeatable/expression/day_in_month.rb
@@ -6,7 +6,11 @@ module Repeatable
       end
 
       def include?(date)
-        date.day == day
+        if day == :last
+          date.next_day.month != date.month
+        else
+          date.day == day
+        end
       end
 
       private

--- a/spec/repeatable/expression/day_in_month_spec.rb
+++ b/spec/repeatable/expression/day_in_month_spec.rb
@@ -74,6 +74,18 @@ module Repeatable
           expect(expression.hash).not_to eq(other_expression.hash)
         end
       end
+
+      describe ':last' do
+        let(:expression) { described_class.new(day: :last) }
+
+        it 'correctly identified the last day of a 31 day month' do
+          expect(expression).to include(::Date.new(2015, 1, 31))
+        end
+
+        it 'correctly identified the last day of a 28 day month' do
+          expect(expression).to include(::Date.new(2015, 2, 28))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I am looking to use this library in a project at work, but found that one of the things its missing for my use case is a way to find the last day of a month. I've added it as a keyword which can be specified for the `day_in_month` class. It would be specified like this:

```ruby
{ day_in_month: { day: :last } }
```

I hope this would be acceptable. Alternatively I could imagine perhaps indexing months from the end of the month using negative indices.

Anyway, thank you for this library, it looks really great so far.