### PR TITLE
Add "difference" expression for modeling set differences

### DIFF
--- a/lib/repeatable.rb
+++ b/lib/repeatable.rb
@@ -23,6 +23,7 @@ require 'repeatable/expression/range_in_year'
 require 'repeatable/expression/set'
 require 'repeatable/expression/union'
 require 'repeatable/expression/intersection'
+require 'repeatable/expression/difference'
 
 require 'repeatable/schedule'
 require 'repeatable/parser'

--- a/lib/repeatable/expression/difference.rb
+++ b/lib/repeatable/expression/difference.rb
@@ -6,8 +6,6 @@ module Repeatable
         @excluded = excluded
       end
 
-      attr_reader :included, :excluded
-
       def include?(date)
         return false if excluded.include?(date)
         included.include?(date)
@@ -21,6 +19,10 @@ module Repeatable
         return false unless other.is_a?(self.class)
         included == other.included && excluded == other.excluded
       end
+
+      protected
+
+      attr_reader :included, :excluded
     end
   end
 end

--- a/lib/repeatable/expression/difference.rb
+++ b/lib/repeatable/expression/difference.rb
@@ -1,0 +1,26 @@
+module Repeatable
+  module Expression
+    class Difference < Base
+      def initialize(included:, excluded:)
+        @included = included
+        @excluded = excluded
+      end
+
+      attr_reader :included, :excluded
+
+      def include?(date)
+        return false if excluded.include?(date)
+        included.include?(date)
+      end
+
+      def to_h
+        Hash[hash_key, { included: included.to_h, excluded: excluded.to_h }]
+      end
+
+      def ==(other)
+        return false unless other.is_a?(self.class)
+        included == other.included && excluded == other.excluded
+      end
+    end
+  end
+end

--- a/lib/repeatable/parser.rb
+++ b/lib/repeatable/parser.rb
@@ -32,6 +32,10 @@ module Repeatable
       when Repeatable::Expression::Set
         args = value.map { |hash| build_expression(hash) }
         klass.new(*args)
+      when Repeatable::Expression::Difference
+        included = build_expression(value[:included] || value["included"])
+        excluded = build_expression(value[:excluded] || value["excluded"])
+        klass.new(included: included, excluded: excluded)
       else
         klass.new(symbolize_keys(value))
       end

--- a/spec/repeatable/expression/difference_spec.rb
+++ b/spec/repeatable/expression/difference_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+module Repeatable
+  module Expression
+    describe Difference do
+      let(:mondays) { Repeatable::Expression::Weekday.new(weekday: 1) }
+      let(:fourths) { Repeatable::Expression::DayInMonth.new(day: 4) }
+      let(:elevenths) { Repeatable::Expression::DayInMonth.new(day: 11) }
+      let(:union) { Repeatable::Expression::Union.new(fourths, elevenths )}
+
+      subject { described_class.new(included: mondays, excluded: union) }
+
+      it_behaves_like 'an expression'
+
+      describe '#include?' do
+        it 'returns true for dates that were not excluded' do
+          expect(subject).to include(::Date.new(2016, 6, 27))
+          expect(subject).to_not include(::Date.new(2016, 7, 4))
+          expect(subject).to_not include(::Date.new(2016, 7, 11))
+          expect(subject).to include(::Date.new(2016, 7, 18))
+        end
+      end
+
+      describe '#to_h' do
+        it 'serializes all the way down' do
+          expect(subject.to_h).to eql({
+            difference: {
+              included: { weekday: { weekday: 1 } },
+              excluded: {
+                union: [
+                  { day_in_month: { day: 4 } },
+                  { day_in_month: { day: 11 } },
+                ],
+              },
+            },
+          })
+        end
+      end
+
+      describe '#==' do
+        it "returns true for the same expressions" do
+          other_expression = described_class.new(included: mondays, excluded: union)
+          expect(subject).to eq(other_expression)
+        end
+
+        it "returns false for different expressions" do
+          other_expression = described_class.new(included: mondays, excluded: fourths)
+          expect(subject).to_not eq(other_expression)
+        end
+
+        it "returns false for a different class of expression" do
+          expect(subject).to_not eq(mondays)
+        end
+      end
+    end
+  end
+end

--- a/spec/repeatable/parser_spec.rb
+++ b/spec/repeatable/parser_spec.rb
@@ -15,6 +15,14 @@ module Repeatable
         end
       end
 
+      context 'difference set expression' do
+        let (:arg) { difference_expression_hash }
+
+        it 'builds the expected Expression object' do
+          expect(subject).to eq(difference_expression_object)
+        end
+      end
+
       context 'with string keys' do
         let(:arg) { stringified_set_expression_hash }
 

--- a/spec/support/schedule_arguments.rb
+++ b/spec/support/schedule_arguments.rb
@@ -49,6 +49,29 @@ module ScheduleArguments
     }
   end
 
+  def difference_expression_hash
+    {
+      difference: {
+        included: { weekday: { weekday: 1 } },
+        excluded: {
+          union: [
+            { day_in_month: { day: 4} },
+            { day_in_month: { day: 11} },
+          ]
+        }
+      }
+    }
+  end
+
+  def difference_expression_object
+    mondays = Repeatable::Expression::Weekday.new(weekday: 1)
+    fourths = Repeatable::Expression::DayInMonth.new(day: 4)
+    elevenths = Repeatable::Expression::DayInMonth.new(day: 11)
+    union = Repeatable::Expression::Union.new(fourths, elevenths)
+
+    Repeatable::Expression::Difference.new(included: mondays, excluded: union)
+  end
+
   def nested_set_expression_object
     twenty_third = Repeatable::Expression::DayInMonth.new(day: 23)
     twenty_fourth = Repeatable::Expression::DayInMonth.new(day: 24)


### PR DESCRIPTION
`Union` and `Intersection` already exist. This change rounds out the set operations by adding a `Difference` expression.

Based on the set operation of:

`[1 2 3 4] - [1 3] => [2 4]`

I gave named keys to the `Difference` expression it could be thought about in terms of:

`included - excluded = difference`