### PR TITLE
Introduce expressions for bounding dates

### DIFF
--- a/lib/repeatable.rb
+++ b/lib/repeatable.rb
@@ -14,6 +14,8 @@ require 'repeatable/expression'
 require 'repeatable/expression/base'
 
 require 'repeatable/expression/date'
+require 'repeatable/expression/date_after'
+require 'repeatable/expression/date_before'
 require 'repeatable/expression/weekday'
 require 'repeatable/expression/biweekly'
 require 'repeatable/expression/weekday_in_month'

--- a/lib/repeatable/expression/date_after.rb
+++ b/lib/repeatable/expression/date_after.rb
@@ -1,0 +1,22 @@
+module Repeatable
+  module Expression
+    class DateAfter < Date
+      def initialize(boundary_date:, include_boundary: true)
+        @boundary_date = Date(boundary_date)
+        @include_boundary = include_boundary
+      end
+
+      def include?(date)
+        if include_boundary
+          (boundary_date.prev_day) < date
+        else
+          boundary_date < date
+        end
+      end
+
+      private
+
+      attr_reader :boundary_date, :include_boundary
+    end
+  end
+end

--- a/lib/repeatable/expression/date_before.rb
+++ b/lib/repeatable/expression/date_before.rb
@@ -1,0 +1,22 @@
+module Repeatable
+  module Expression
+    class DateBefore < Date
+      def initialize(boundary_date:, include_boundary: true)
+        @boundary_date = Date(boundary_date)
+        @include_boundary = include_boundary
+      end
+
+      def include?(date)
+        if include_boundary
+          date < (boundary_date.next_day)
+        else
+          date < boundary_date
+        end
+      end
+
+      private
+
+      attr_reader :boundary_date, :include_boundary
+    end
+  end
+end

--- a/spec/repeatable/expression/date_after_spec.rb
+++ b/spec/repeatable/expression/date_after_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+module Repeatable
+  module Expression
+    describe DateAfter do
+      subject { described_class.new(args) }
+      let(:args) { { boundary_date: boundary_date, include_boundary: include_boundary } }
+      let(:boundary_date) { ::Date.new(2016, 8, 25) }
+
+      context 'include boundary is false' do
+        let(:include_boundary) { false }
+
+        it 'does not include a far-past date before the boundary date' do
+          expect(subject).not_to include(::Date.new(2015, 8, 26))
+        end
+
+        it 'does not include the date immediately before the boundary date' do
+          expect(subject).not_to include(::Date.new(2016, 8, 24))
+        end
+
+        it 'does not include the boundary date' do
+          expect(subject).not_to include(::Date.new(2016, 8, 25))
+        end
+
+        it 'includes the date immediate after the boundary date' do
+          expect(subject).to include(::Date.new(2016, 8, 26))
+        end
+
+        it 'includes a far-future date after the boundary date' do
+          expect(subject).to include(::Date.new(2017, 8, 24))
+        end
+      end
+
+      context 'include_boundary is true' do
+        let(:include_boundary) { true }
+
+        it 'does not include a far-past date before the boundary date' do
+          expect(subject).not_to include(::Date.new(2015, 8, 26))
+        end
+
+        it 'does not include the date immediately before the boundary date' do
+          expect(subject).not_to include(::Date.new(2016, 8, 24))
+        end
+
+        it 'includes the boundary date' do
+          expect(subject).to include(::Date.new(2016, 8, 25))
+        end
+
+        it 'includes the date immediate after the boundary date' do
+          expect(subject).to include(::Date.new(2016, 8, 26))
+        end
+
+        it 'includes a far-future date after the boundary date' do
+          expect(subject).to include(::Date.new(2017, 8, 24))
+        end
+      end
+    end
+  end
+end

--- a/spec/repeatable/expression/date_before_spec.rb
+++ b/spec/repeatable/expression/date_before_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+module Repeatable
+  module Expression
+    describe DateBefore do
+      subject { described_class.new(args) }
+      let(:args) { { boundary_date: boundary_date, include_boundary: include_boundary } }
+      let(:boundary_date) { ::Date.new(2016, 8, 25) }
+
+      context 'include boundary is false' do
+        let(:include_boundary) { false }
+
+        it 'includes a far-past date before the boundary date' do
+          expect(subject).to include(::Date.new(2015, 8, 26))
+        end
+
+        it 'includes the date immediately before the boundary date' do
+          expect(subject).to include(::Date.new(2016, 8, 24))
+        end
+
+        it 'does not include the boundary date' do
+          expect(subject).not_to include(::Date.new(2016, 8, 25))
+        end
+
+        it 'does not include the date immediate after the boundary date' do
+          expect(subject).not_to include(::Date.new(2016, 8, 26))
+        end
+
+        it 'does not include a far-future date after the boundary date' do
+          expect(subject).not_to include(::Date.new(2017, 8, 24))
+        end
+      end
+
+      context 'include_boundary is true' do
+        let(:include_boundary) { true }
+
+        it 'includes a far-past date before the boundary date' do
+          expect(subject).to include(::Date.new(2015, 8, 26))
+        end
+
+        it 'includes the date immediately before the boundary date' do
+          expect(subject).to include(::Date.new(2016, 8, 24))
+        end
+
+        it 'includes the boundary date' do
+          expect(subject).to include(::Date.new(2016, 8, 25))
+        end
+
+        it 'does not include the date immediate after the boundary date' do
+          expect(subject).not_to include(::Date.new(2016, 8, 26))
+        end
+
+        it 'does not include a far-future date after the boundary date' do
+          expect(subject).not_to include(::Date.new(2017, 8, 24))
+        end
+      end
+    end
+  end
+end

--- a/spec/repeatable/parser_spec.rb
+++ b/spec/repeatable/parser_spec.rb
@@ -23,6 +23,31 @@ module Repeatable
         end
       end
 
+      context 'date before and date after expressions' do
+        let (:arg) {
+          {
+            intersection: [
+              { date_after:  { boundary_date: '2016-01-01', include_boundary: true } },
+              { date_before: { boundary_date: '2017-01-01', include_boundary: false } },
+            ]
+          }
+        }
+
+        it 'builds the expected expression objects' do
+          expected_expression = Repeatable::Expression::Intersection.new(
+            Repeatable::Expression::DateAfter.new(
+              boundary_date: ::Date.new(2016, 1, 1),
+              include_boundary: true
+            ),
+            Repeatable::Expression::DateBefore.new(
+              boundary_date: ::Date.new(2017, 1, 1),
+              include_boundary: false,
+            ),
+          )
+          expect(subject).to eq(expected_expression)
+        end
+      end
+
       context 'with string keys' do
         let(:arg) { stringified_set_expression_hash }
 


### PR DESCRIPTION
There are some problems that are best represented by expressions of the form:

> "I want all dates that are (on or) after a specific date"

or

> "I want all dates that are (on or) before a specific date"

While this is possible with `Schedule#occurrences(before_date, after_date)`, there are some problems where it would be nice to encode these requirements within the `Schedule` or `Expression` itself.