### PR TITLE
Add ExactDate expression

### DIFF
--- a/lib/repeatable.rb
+++ b/lib/repeatable.rb
@@ -14,6 +14,7 @@ require 'repeatable/expression'
 require 'repeatable/expression/base'
 
 require 'repeatable/expression/date'
+require 'repeatable/expression/exact_date'
 require 'repeatable/expression/weekday'
 require 'repeatable/expression/biweekly'
 require 'repeatable/expression/weekday_in_month'

--- a/lib/repeatable/expression/exact_date.rb
+++ b/lib/repeatable/expression/exact_date.rb
@@ -1,0 +1,17 @@
+module Repeatable
+  module Expression
+    class ExactDate < Date
+      def initialize(date:)
+        @date = Date(date)
+      end
+
+      def include?(other_date)
+        date == other_date
+      end
+
+      private
+
+      attr_reader :date
+    end
+  end
+end

--- a/spec/repeatable/expression/exact_date_spec.rb
+++ b/spec/repeatable/expression/exact_date_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+module Repeatable
+  module Expression
+    describe ExactDate do
+      subject { described_class.new(date: ::Date.new(2016, 8, 25)) }
+
+      it_behaves_like 'an expression'
+
+      describe '#include?' do
+        it 'returns true for the exact date' do
+          expect(subject).to include(::Date.new(2016, 8, 25))
+        end
+
+        it 'returns false for dates not matching the day given' do
+          expect(subject).not_to include(::Date.new(2015, 8, 25))
+          expect(subject).not_to include(::Date.new(2016, 8, 24))
+          expect(subject).not_to include(::Date.new(2016, 8, 26))
+          expect(subject).not_to include(::Date.new(2017, 8, 25))
+        end
+      end
+
+      describe '#to_h' do
+        it 'returns a hash with the class name and arguments' do
+          expect(subject.to_h).to eq(exact_date: { date: "2016-08-25" })
+        end
+      end
+
+      describe '#==' do
+        it 'returns true if the expressions have the same argument' do
+          other_expression = described_class.new(date: ::Date.new(2016, 8, 25))
+          expect(subject).to eq(other_expression)
+        end
+
+        it 'returns true if the expression was initialized from a string' do
+          other_expression = described_class.new(date: '2016-08-25')
+          expect(subject).to eq(other_expression)
+        end
+
+        it 'returns false if the expressions do not have the same argument' do
+          other_expression = described_class.new(date: ::Date.new(2016, 8, 26))
+          expect(subject).not_to eq(other_expression)
+        end
+
+        it 'returns false if the given expression is not a ExactDate' do
+          expect(subject).not_to eq(Weekday.new(weekday: 2))
+        end
+      end
+
+      describe '#eql?' do
+        it 'returns true if the expressions have the same argument' do
+          other_expression = described_class.new(date: ::Date.new(2016, 8, 25))
+          expect(subject).to eql(other_expression)
+        end
+
+        it 'returns false if the expressions do not have the same argument' do
+          other_expression = described_class.new(date: ::Date.new(2016, 8, 26))
+          expect(subject).not_to eql(other_expression)
+        end
+
+        it 'returns false if the given expression is not a DayInMonth' do
+          other_expression = Weekday.new(weekday: 2)
+          expect(subject).not_to eql(other_expression)
+        end
+      end
+
+      describe '#hash' do
+        it 'of two expressions with the same arguments are the same' do
+          other_expression = described_class.new(date: ::Date.new(2016, 8, 25))
+          expect(subject.hash).to eq(other_expression.hash)
+        end
+
+        it 'of two expressions with different arguments are not the same' do
+          other_expression = described_class.new(date: ::Date.new(2016, 8, 26))
+          expect(subject.hash).not_to eq(other_expression.hash)
+        end
+
+        it 'of two expressions of different types are not the same' do
+          other_expression = Weekday.new(weekday: 2)
+          expect(subject.hash).not_to eq(other_expression.hash)
+        end
+      end
+
+      describe 'parsing' do
+        it 'works with the Repeatable::Parser' do
+          restored_from_hash = Repeatable::Parser.call(subject.to_h)
+          expect(subject).to eq(restored_from_hash)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When working with calendars it is a common task to omit specific dates. This commit adds an `ExactDate` expression that can model these omissions very clearly.

Let's say you have a basketball practice that meets every Monday, except on July 4 2016 because that is a holiday. With this new Expression you could model this as:

```ruby
schedule_with_cancellations = Repeatable::Schedule.new({
  difference: {
    included: { weekday: { weekday: 1 } },
    excluded: { exact_date: { date: "2016-07-04" } },
  },
})
```