### PR TITLE
fix(RangeInYear) `start_day` and `end_day` with `start_month == end_month`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ addons:
   code_climate:
     repo_token:
       secure: fyZ7Ycc23fzfh8bBiqPUhlJGcIcnanZWqVc4nsKDJeE1G5ScW01+ot1g4miDWxo7w80gKRKP/PfoYf6lOQ1B5yJJCV0Z5fjoTW3y+EKksMuGNCFaWh8R73MIPlVtfOazGyI2t3l4zDWoik906wHHNQJFveMZawvZGrVMWF6YxKg=
+after_success:
+  - bundle exec codeclimate-test-reporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Features:
 
 * Add `Expression::Difference` for set differences between 2 schedules ([@danott][])
 * Allow `Expression::DayInMonth` to take `:last` (or `'last'`) for its `day:` argument ([@PatrickLerner][])
+* Fix `Expression::RangeInYear` to properly handle using `start_day` and `end_day` when `start_month == end_month` ([@danielma][])
 
 [Commits](https://github.com/molawson/repeatable/compare/v0.5.0...master)
 
@@ -71,3 +72,4 @@ Initial Release
 
 [@danott]: https://github.com/danott
 [@PatrickLerner]: https://github.com/PatrickLerner
+[@danielma]: https://github.com/danielma

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'pry'
-gem 'codeclimate-test-reporter', group: :test, require: nil
+group :test do
+  gem 'simplecov'
+  gem 'codeclimate-test-reporter', '~> 1.0.0'
+end

--- a/lib/repeatable/expression/range_in_year.rb
+++ b/lib/repeatable/expression/range_in_year.rb
@@ -9,7 +9,13 @@ module Repeatable
       end
 
       def include?(date)
-        months_include?(date) || start_month_include?(date) || end_month_include?(date)
+        return true if months_include?(date)
+
+        if start_month == end_month
+          start_month_include?(date) && end_month_include?(date)
+        else
+          start_month_include?(date) || end_month_include?(date)
+        end
       end
 
       def to_h

--- a/spec/repeatable/expression/range_in_year_spec.rb
+++ b/spec/repeatable/expression/range_in_year_spec.rb
@@ -123,6 +123,20 @@ module Repeatable
             expect(subject).not_to include(::Date.new(2015, 11, 1))
           end
         end
+
+        context 'start month equals end month' do
+          let(:args) { { start_month: 8, end_month: 8, start_day: 20, end_day: 21 } }
+
+          it 'return true when the date falls on or after the start_day in the start_month' do
+            expect(subject).to include(::Date.new(2015, 8, 20))
+            expect(subject).to include(::Date.new(2015, 8, 21))
+          end
+
+          it 'return false when the date falls outside the start_day in the start_month' do
+            expect(subject).not_to include(::Date.new(2015, 8, 19))
+            expect(subject).not_to include(::Date.new(2015, 8, 22))
+          end
+        end
       end
 
       describe '#to_h' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'repeatable'
 
-Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+Dir['./spec/support/**/*.rb'].sort.each { |f| require f }


### PR DESCRIPTION
Fix an issue with `Expression::RangeInYear` where `start_day` and
`end_day` would not be properly respected if `start_month == end_month`.