### PR TITLE
feat(WeekdayInMonth): support negative count

### DIFF
--- a/lib/repeatable/expression/weekday_in_month.rb
+++ b/lib/repeatable/expression/weekday_in_month.rb
@@ -19,11 +19,24 @@ module Repeatable
       end
 
       def week_matches?(date)
-        week_in_month(date.day) == count
+        week_in_month(date) == count
       end
 
-      def week_in_month(day)
-        ((day - 1) / 7) + 1
+      def week_in_month(date)
+        zero_indexed_day = if count.negative?
+                             last_day_of_month(date).day - date.day
+                           else
+                             date.day - 1
+                           end
+        zero_indexed_week = zero_indexed_day / 7
+
+        (count.negative? ? -1 : 1) * (zero_indexed_week + 1)
+      end
+
+      def last_day_of_month(date)
+        next_month = date.next_month
+        first_day_of_next_month = ::Date.new(next_month.year, next_month.month, 1)
+        first_day_of_next_month.prev_day
       end
     end
   end

--- a/lib/repeatable/expression/weekday_in_month.rb
+++ b/lib/repeatable/expression/weekday_in_month.rb
@@ -23,17 +23,18 @@ module Repeatable
       end
 
       def week_in_month(date)
-        zero_indexed_day = if count.negative?
-                             last_day_of_month(date).day - date.day
+        negative_count = count < 0
+        zero_indexed_day = if negative_count
+                             last_date_of_month(date).day - date.day
                            else
                              date.day - 1
                            end
         zero_indexed_week = zero_indexed_day / 7
 
-        (count.negative? ? -1 : 1) * (zero_indexed_week + 1)
+        (negative_count ? -1 : 1) * (zero_indexed_week + 1)
       end
 
-      def last_day_of_month(date)
+      def last_date_of_month(date)
         next_month = date.next_month
         first_day_of_next_month = ::Date.new(next_month.year, next_month.month, 1)
         first_day_of_next_month.prev_day

--- a/spec/repeatable/expression/weekday_in_month_spec.rb
+++ b/spec/repeatable/expression/weekday_in_month_spec.rb
@@ -89,6 +89,36 @@ module Repeatable
           expect(expression.hash).not_to eq(other_expression.hash)
         end
       end
+
+      describe 'negative week' do
+        context 'last week' do
+          subject { described_class.new(weekday: 3, count: -1) }
+
+          it 'matches valid dates' do
+            expect(subject).to include(::Date.new(2017, 12, 27))
+            expect(subject).to include(::Date.new(2017, 5, 31))
+          end
+
+          it 'does not match invalid dates' do
+            expect(subject).not_to include(::Date.new(2017, 12, 28))
+            expect(subject).not_to include(::Date.new(2017, 5, 24))
+          end
+        end
+
+        context '2nd to last week' do
+          subject { described_class.new(weekday: 1, count: -2) }
+
+          it 'matches valid dates' do
+            expect(subject).to include(::Date.new(2017, 12, 18))
+            expect(subject).to include(::Date.new(2017, 5, 22))
+          end
+
+          it 'does not match invalid dates' do
+            expect(subject).not_to include(::Date.new(2017, 12, 27))
+            expect(subject).not_to include(::Date.new(2017, 5, 31))
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This adds the ability to represent expressions like

```
The last Wednesday of the month     => WeekDayInMonth.new(weekday: 3, count: -1)
The 2nd to last Monday of the month => WeekdayInMonth.new(weekday: 1, count: -2)
```

It also attempts to clarify the intent of the procedure for
determining the week of the month from a given date with named
variables for the steps of the process.