### PR TITLE
Bring consistency to DayInMonth and WeekdayInMonth APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+Breaking Changes:
+
+* Change `Expression::DayInMonth` to take negative numbers instead of special `:last` symbol (or string)
+
 Chores:
 
 * Remove support for Ruby 2.1.x
@@ -18,7 +22,7 @@ Features:
 * Allow `Expression::DayInMonth` to take `:last` (or `'last'`) for its `day:` argument ([@PatrickLerner][])
 * Allow `Expression::WeekdayInMonth` to take negative `count` argument for last, second-to-last, etc. of a given weekday ([@danielma][])
 
-Bugfixes:
+Bug Fixes:
 
 * Fix `Expression::RangeInYear` to properly handle using `start_day` and `end_day` when `start_month == end_month` ([@danielma][])
 
@@ -58,7 +62,7 @@ Features:
 * Add `ParseError` class for better error handling
 * Extract `Parser` class from `Schedule`
 
-Bugfixes:
+Bug Fixes:
 
 * Enable `Schedule` to take a hash with string keys
 
@@ -71,7 +75,7 @@ Features:
 * Add `Schedule#to_h` and `Expression#to_h` methods
 * Enable building a `Schedule` from composed `Expression` objects
 
-Bugfixes:
+Bug Fixes:
 
 * Fix default case equality for `Expression::Base` to work with classes and instances
 

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Repeatable::Expression::Biweekly.new(weekday: 1, start_date: Date.new(2015, 12, 
 Repeatable::Expression::DayInMonth.new(day: 13)
 
 # The last day of every month
-{ day_in_month: { day: :last } }
-Repeatable::Expression::DayInMonth.new(day: :last)
+{ day_in_month: { day: -1 } }
+Repeatable::Expression::DayInMonth.new(day: -1)
 
 # All days in October
 { range_in_year: { start_month: 10 } }

--- a/lib/repeatable.rb
+++ b/lib/repeatable.rb
@@ -10,6 +10,8 @@ end
 
 require 'repeatable/parse_error'
 
+require 'repeatable/last_date_of_month'
+
 require 'repeatable/expression'
 require 'repeatable/expression/base'
 

--- a/lib/repeatable/expression/day_in_month.rb
+++ b/lib/repeatable/expression/day_in_month.rb
@@ -1,13 +1,15 @@
 module Repeatable
   module Expression
     class DayInMonth < Date
+      include LastDateOfMonth
+
       def initialize(day:)
         @day = day
       end
 
       def include?(date)
-        if day.to_s == 'last'
-          date.next_day.month != date.month
+        if day < 0
+          date - last_date_of_month(date) - 1 == day
         else
           date.day == day
         end

--- a/lib/repeatable/expression/weekday_in_month.rb
+++ b/lib/repeatable/expression/weekday_in_month.rb
@@ -1,6 +1,8 @@
 module Repeatable
   module Expression
     class WeekdayInMonth < Date
+      include LastDateOfMonth
+
       def initialize(weekday:, count:)
         @weekday = weekday
         @count = count
@@ -36,12 +38,6 @@ module Repeatable
 
       def week_in_month(zero_indexed_day)
         (zero_indexed_day / 7) + 1
-      end
-
-      def last_date_of_month(date)
-        next_month = date.next_month
-        first_day_of_next_month = ::Date.new(next_month.year, next_month.month, 1)
-        first_day_of_next_month.prev_day
       end
 
       def negative_count?

--- a/lib/repeatable/last_date_of_month.rb
+++ b/lib/repeatable/last_date_of_month.rb
@@ -1,0 +1,7 @@
+module Repeatable
+  module LastDateOfMonth
+    def last_date_of_month(date)
+      ::Date.new(date.next_month.year, date.next_month.month, 1).prev_day
+    end
+  end
+end

--- a/spec/repeatable/expression/day_in_month_spec.rb
+++ b/spec/repeatable/expression/day_in_month_spec.rb
@@ -75,27 +75,29 @@ module Repeatable
         end
       end
 
-      describe ':last' do
-        let(:expression) { described_class.new(day: :last) }
+      describe 'negative numbers' do
+        context 'last' do
+          let(:expression) { described_class.new(day: -1) }
 
-        it 'correctly identified the last day of a 31 day month' do
-          expect(expression).to include(::Date.new(2015, 1, 31))
+          it 'correctly identified the last day of a 31 day month' do
+            expect(expression).to include(::Date.new(2015, 1, 31))
+          end
+
+          it 'correctly identified the last day of a 28 day month' do
+            expect(expression).to include(::Date.new(2015, 2, 28))
+          end
         end
 
-        it 'correctly identified the last day of a 28 day month' do
-          expect(expression).to include(::Date.new(2015, 2, 28))
-        end
-      end
+        context '3rd to last' do
+          let(:expression) { described_class.new(day: -3) }
 
-      describe '"last"' do
-        let(:expression) { described_class.new(day: 'last') }
+          it 'correctly identified the 3rd to last day of a 31 day month' do
+            expect(expression).to include(::Date.new(2015, 1, 29))
+          end
 
-        it 'correctly identified the last day of a 31 day month' do
-          expect(expression).to include(::Date.new(2015, 1, 31))
-        end
-
-        it 'correctly identified the last day of a 28 day month' do
-          expect(expression).to include(::Date.new(2015, 2, 28))
+          it 'correctly identified the 3rd to last day of a 28 day month' do
+            expect(expression).to include(::Date.new(2015, 2, 26))
+          end
         end
       end
     end

--- a/spec/repeatable/last_date_of_month_spec.rb
+++ b/spec/repeatable/last_date_of_month_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+module Repeatable
+  describe LastDateOfMonth do
+    include LastDateOfMonth
+
+    describe '#last_date_of_month' do
+      it 'returns the last day of the month for a 28 day month' do
+        date = Date.new(2017, 2, 12)
+        expect(last_date_of_month(date)).to eq(Date.new(2017, 2, 28))
+      end
+
+      it 'returns the last day of the month for a 29 day month' do
+        date = Date.new(2016, 2, 20)
+        expect(last_date_of_month(date)).to eq(Date.new(2016, 2, 29))
+      end
+
+      it 'returns the last day of the month for a 30 day month' do
+        date = Date.new(2017, 4, 9)
+        expect(last_date_of_month(date)).to eq(Date.new(2017, 4, 30))
+      end
+
+      it 'returns the last day of the month for a 31 day month' do
+        date = Date.new(2017, 1, 2)
+        expect(last_date_of_month(date)).to eq(Date.new(2017, 1, 31))
+      end
+
+      it 'returns the last day of the month for a date that is the last day' do
+        date = Date.new(2017, 1, 31)
+        expect(last_date_of_month(date)).to eq(Date.new(2017, 1, 31))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Change

The use of a special `:last` symbol (or string) for defining an expression for the last day of a month worked well.

Now that we have added the ability to do a similar thing for `WeekdayInMonth` and ended up with a more Ruby-ish and more flexible negative number system for describing the number of weeks (or days) from the end of a month, it follows that we'd updated `DayInMonth` to match.

### Benefits

This gives us increased flexibility to define (in the somewhat rare case that you'd need it) something like "3rd to last day of the month." More importantly, it brings consistency to the interfaces of these classes and removes a "magic" symbol/string.


_(P.S. - I'm doing this in a PR mostly for discoverability)_