### PR TITLE
Flatten unions during initialization

### DIFF
--- a/lib/repeatable/expression/set.rb
+++ b/lib/repeatable/expression/set.rb
@@ -1,6 +1,8 @@
 module Repeatable
   module Expression
     class Set < Base
+      attr_reader :elements
+
       def initialize(*elements)
         @elements = elements.flatten.uniq
       end
@@ -19,10 +21,6 @@ module Repeatable
           elements.size == other.elements.size &&
           other.elements.all? { |e| elements.include?(e) }
       end
-
-      protected
-
-      attr_reader :elements
     end
   end
 end

--- a/lib/repeatable/expression/union.rb
+++ b/lib/repeatable/expression/union.rb
@@ -1,6 +1,11 @@
 module Repeatable
   module Expression
     class Union < Set
+      def initialize(*elements)
+        other_unions, not_unions = elements.partition { |e| e.is_a?(self.class) }
+        super(other_unions.flat_map(&:elements) + not_unions)
+      end
+
       def include?(date)
         elements.any? { |e| e.include?(date) }
       end

--- a/spec/repeatable/expression/union_spec.rb
+++ b/spec/repeatable/expression/union_spec.rb
@@ -8,6 +8,31 @@ module Repeatable
 
       it_behaves_like 'an expression'
 
+      describe '#initialize' do
+        context 'when there are no Union elements' do
+          subject { described_class.new(twenty_third) }
+
+          it 'returns all elements as is' do
+            expected_hash = { union: [{ day_in_month: { day: 23 } }] }
+            expect(subject.to_h).to eq(expected_hash)
+          end
+        end
+
+        context 'when there are Union elements' do
+          subject { described_class.new(twenty_third) + oct_thru_dec }
+
+          specify do
+            expected_hash = {
+              union: [
+                { day_in_month: { day: 23 } },
+                { range_in_year: { start_month: 10, end_month: 12 } }
+              ]
+            }
+            expect(subject.to_h).to eq(expected_hash)
+          end
+        end
+      end
+
       describe '#include?' do
         subject { described_class.new(twenty_third, oct_thru_dec) }
 

--- a/spec/repeatable/expression/union_spec.rb
+++ b/spec/repeatable/expression/union_spec.rb
@@ -6,11 +6,11 @@ module Repeatable
       let(:twenty_third) { Repeatable::Expression::DayInMonth.new(day: 23) }
       let(:oct_thru_dec) { Repeatable::Expression::RangeInYear.new(start_month: 10, end_month: 12) }
 
-      subject { described_class.new(twenty_third, oct_thru_dec) }
-
       it_behaves_like 'an expression'
 
       describe '#include?' do
+        subject { described_class.new(twenty_third, oct_thru_dec) }
+
         it 'returns true for dates that match any expression' do
           expect(subject.include?(::Date.new(2015, 9, 2))).to eq(false)
           expect(subject.include?(::Date.new(2015, 9, 23))).to eq(true)

--- a/spec/repeatable/parser_spec.rb
+++ b/spec/repeatable/parser_spec.rb
@@ -15,6 +15,14 @@ module Repeatable
         end
       end
 
+      context 'complex union expression' do
+        let(:arg) { nested_union_expression_hash }
+
+        it 'builds the expected Expression object' do
+          expect(subject).to eq(nested_union_expression_object)
+        end
+      end
+
       context 'difference set expression' do
         let (:arg) { difference_expression_hash }
 

--- a/spec/support/schedule_arguments.rb
+++ b/spec/support/schedule_arguments.rb
@@ -35,6 +35,23 @@ module ScheduleArguments
     }
   end
 
+  def nested_union_expression_hash
+    {
+      union: [
+        { day_in_month: { day: 23 } },
+        union: [
+          { day_in_month: { day: 24 } },
+          union: [
+            { day_in_month: { day: 25 } },
+            union: [
+              { day_in_month: { day: 26 } }
+            ]
+          ]
+        ]
+      ]
+    }
+  end
+
   def reordered_nested_set_expression_hash
     {
       intersection: [
@@ -79,5 +96,14 @@ module ScheduleArguments
     oct_thru_dec = Repeatable::Expression::RangeInYear.new(start_month: 10, end_month: 12)
 
     Repeatable::Expression::Intersection.new(union, oct_thru_dec)
+  end
+
+  def nested_union_expression_object
+    twenty_third = Repeatable::Expression::DayInMonth.new(day: 23)
+    twenty_fourth = Repeatable::Expression::DayInMonth.new(day: 24)
+    twenty_fifth = Repeatable::Expression::DayInMonth.new(day: 25)
+    twenty_sixth = Repeatable::Expression::DayInMonth.new(day: 26)
+
+    Repeatable::Expression::Union.new(twenty_third, twenty_fourth, twenty_fifth, twenty_sixth)
   end
 end


### PR DESCRIPTION
Two unions are equivalent as long as the non-union elements of the set are the same. Using a hash as an example, `nested_set` and `flattened_set` are equivalent:
```
nested_set = {
  union: [
    { day_in_month: { day: 23 } },
    union: [
      { day_in_month: { day: 24 } },
      union: [
        { day_in_month: { day: 25 } },
        union: [
          { day_in_month: { day: 26 } }
        ]
      ]
    ]
  ]
}
flattened_set = {
  union: [
    { day_in_month: { day: 23 } },
    { day_in_month: { day: 24 } },
    { day_in_month: { day: 25 } },
    { day_in_month: { day: 26 } }
  ]
}
```

This changes Union initialization, flattening any elements that are themselves Unions.