### PR TITLE
feat(Daily): add new expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+Changes:
+
+* Add `Daily` expression
+
 [Commits](https://github.com/molawson/repeatable/compare/v1.1.0...main)
 
 ### 1.1.0 (2022-02-25)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Repeatable::Expression::Difference.new(included: expression, excluded: another_e
 
 # DATES
 
+# Every day
+{ daily: {} }
+Repeatable::Expression::Daily.new
+
 # Every Sunday
 { weekday: { weekday: 0 } }
 Repeatable::Expression::Weekday.new(weekday: 0)

--- a/lib/repeatable.rb
+++ b/lib/repeatable.rb
@@ -18,6 +18,7 @@ require "repeatable/expression"
 require "repeatable/expression/base"
 
 require "repeatable/expression/date"
+require "repeatable/expression/daily"
 require "repeatable/expression/exact_date"
 require "repeatable/expression/weekday"
 require "repeatable/expression/biweekly"

--- a/lib/repeatable/expression/daily.rb
+++ b/lib/repeatable/expression/daily.rb
@@ -1,0 +1,11 @@
+# typed: strict
+module Repeatable
+  module Expression
+    class Daily < Date
+      sig { override.params(_date: ::Date).returns(T::Boolean) }
+      def include?(_date)
+        true
+      end
+    end
+  end
+end

--- a/spec/repeatable/expression/daily_spec.rb
+++ b/spec/repeatable/expression/daily_spec.rb
@@ -1,0 +1,36 @@
+# typed: false
+require "spec_helper"
+
+module Repeatable
+  module Expression
+    describe Daily do
+      subject { described_class.new }
+
+      it_behaves_like "an expression"
+
+      describe "#include?" do
+        it "is true" do
+          expect(subject).to include(::Date.new(2015, 1, 1))
+        end
+      end
+
+      describe "#to_h" do
+        it "returns a hash with the class name and arguments" do
+          expect(subject.to_h).to eq(daily: {})
+        end
+      end
+
+      describe "#==" do
+        it "returns true" do
+          expect(described_class.new).to eq(described_class.new)
+        end
+      end
+
+      describe "#eql?" do
+        it "returns true" do
+          expect(described_class.new).to eql(described_class.new)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're using Repeatable to build a task manager, and in that task manager, we want to support daily repeating tasks.

Our current implementation looks like this:

```ruby
daily = Repeatable::Schedule.new(
  union: [
    { weekday: { weekday: 0 } },
    { weekday: { weekday: 1 } },
    { weekday: { weekday: 2 } },
    { weekday: { weekday: 3 } },
    { weekday: { weekday: 4 } },
    { weekday: { weekday: 5 } },
    { weekday: { weekday: 6 } },
  ]
)
```

While the `Daily` expression is extremely simple, it is utile, and allows for simpler storage and expression of this pattern.