### PR TITLE
Support Ruby 2.7+ Pattern Matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+Changes:
+
+* Support pattern matching for `Expression` and `Schedule`
+
 [Commits](https://github.com/molawson/repeatable/compare/v1.1.0...main)
 
 ### 1.1.0 (2022-02-25)

--- a/README.md
+++ b/README.md
@@ -159,6 +159,21 @@ schedule.to_h
   #    can be used to recreate an identical Schedule object at a later time
 ```
 
+#### Pattern Matching
+
+Both `Repeatable::Schedule` and all `Repeatable::Expression` classes support Ruby 2.7+ [pattern matching][ruby-pattern-matching] which is particularly useful for parsing or presenting an existing schedule.
+
+```ruby
+case schedule
+in weekday: { weekday: }
+  "Weekly on #{Date::DAYNAMES[weekday]}"
+in day_in_month: { day: }
+  "Every month on the #{day.ordinalize}"
+in weekday_in_month: { weekday:, count: }
+  "Every month on the #{count.ordinalize} #{Date::DAYNAMES[weekday]}"
+end
+```
+
 #### Equivalence
 
 Both `Repeatable::Schedule` and all `Repeatable::Expression` classes have equivalence `#==` defined according to what's appropriate for each class, so regardless of the order of arguments passed to each, you can tell whether one object is equivalent to the other in terms of whether or not, when asked the same questions, you'd receive the same results from each.
@@ -218,3 +233,5 @@ The gem is available as open source under the terms of the [MIT License](https:/
 ## Code of Conduct
 
 Everyone interacting in the Repeatable project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/molawson/repeatable/blob/main/CODE_OF_CONDUCT.md).
+
+[ruby-pattern-matching]: https://docs.ruby-lang.org/en/3.0/syntax/pattern_matching_rdoc.html

--- a/lib/repeatable/expression/base.rb
+++ b/lib/repeatable/expression/base.rb
@@ -26,6 +26,11 @@ module Repeatable
         {hash_key => hash_value}
       end
 
+      sig { params(_keys: T.nilable(T::Array[Symbol])).returns(T::Hash[Symbol, T.any(Types::SymbolHash, T::Array[Types::SymbolHash])]) }
+      def deconstruct_keys(_keys)
+        to_h
+      end
+
       sig { params(other: Expression::Base).returns(Expression::Union) }
       def union(other)
         Union.new(self, other)

--- a/lib/repeatable/schedule.rb
+++ b/lib/repeatable/schedule.rb
@@ -54,6 +54,11 @@ module Repeatable
       expression.to_h
     end
 
+    sig { params(_keys: T.nilable(T::Array[Symbol])).returns(T::Hash[Symbol, T.any(Types::SymbolHash, T::Array[Types::SymbolHash])]) }
+    def deconstruct_keys(_keys)
+      to_h
+    end
+
     sig { params(other: Object).returns(T::Boolean) }
     def ==(other)
       other.is_a?(self.class) && expression == other.expression

--- a/spec/repeatable/schedule_spec.rb
+++ b/spec/repeatable/schedule_spec.rb
@@ -328,6 +328,14 @@ module Repeatable
       end
     end
 
+    describe "pattern matching" do
+      let(:arg) { nested_set_expression_hash }
+
+      it "can #deconstruct_keys" do
+        expect(subject.deconstruct_keys(nil)).to eq subject.to_h
+      end
+    end
+
     describe "#==" do
       it "returns true if the schedules have the same identity" do
         schedule = described_class.new(nested_set_expression_object)

--- a/spec/support/expression_examples.rb
+++ b/spec/support/expression_examples.rb
@@ -11,4 +11,10 @@ shared_examples "an expression" do
       expect { subject.to_h }.not_to raise_error
     end
   end
+
+  describe "pattern matching" do
+    it "can #deconstruct_keys" do
+      expect(subject.deconstruct_keys(nil)).to be_a(Hash)
+    end
+  end
 end


### PR DESCRIPTION
Add `#deconstruct_keys` to `Expression::Base` and `Schedule` so that they can be used in pattern matches.

In our products, we've been using `#to_h` for this, and it would be nice sugar to have it built in.

A common example we've used in our products is building a humanized-readable version of a schedule. An extremely stripped down version might look something like this

```ruby
case existing_user_schedule
in weekday: { weekday: }
  "Every #{weekday}"
in day_in_month: { day: }
  "Last #{day} of every month"
end
```